### PR TITLE
Add '/docs' redirect to '/docs/generated' for generated HTML.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
-    <link rel="canonical" href="/generated/" />
-    <meta http-equiv=refresh content="0; url=/generated/" />
+    <link rel="canonical" href="/nakama-unity/generated/" />
+    <meta http-equiv=refresh content="0; url=/nakama-unity/generated/" />
     <meta name="robots" content="noindex,follow" />
     <meta http-equiv="cache-control" content="no-cache" />
   </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <link rel="canonical" href="/generated/" />
+    <meta http-equiv=refresh content="0; url=/generated/" />
+    <meta name="robots" content="noindex,follow" />
+    <meta http-equiv="cache-control" content="no-cache" />
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
This should fix the broken root URL with gh-pages because we cannot select a subfolder of the 'docs' directory as the root of the HTML content.

@mofirouz review plz