### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ nunit.dependsOn msbuild
 def editor = '/Applications/Unity/Unity.app/Contents/MacOS/Unity'
 switch (OperatingSystem.current().getName()) {
 case "windows":
+case "Windows 10":
   editor = /C:\Program Files\Unity\Editor\Unity.exe/
   break
 case "linux":


### PR DESCRIPTION
Add a case for Windows 10.  I suggest though changing this to assume Unity is on the Path like the rest of the build dependencies.