### PR TITLE
Enable finer control over what thread and when callbacks are executed on.

### DIFF
--- a/Nakama/INClient.cs
+++ b/Nakama/INClient.cs
@@ -69,5 +69,7 @@ namespace Nakama
         void Register(INAuthenticateMessage message, Action<INSession> callback, Action<INError> errback);
 
         void Send<T>(INMessage<T> message, Action<T> callback, Action<INError> errback);
+
+        void ProcessCallbacks();
     }
 }

--- a/Nakama/NClient.cs
+++ b/Nakama/NClient.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
@@ -25,10 +26,8 @@ using System.Threading;
 using Google.Protobuf;
 using WebSocketSharp;
 
-namespace Nakama
-{
-    public class NClient : INClient
-    {
+namespace Nakama {
+    public class NClient : INClient {
         public uint ConnectTimeout { get; private set; }
 
         public string Host { get; private set; }
@@ -53,11 +52,9 @@ namespace Nakama
 
         public string ServerKey { get; private set; }
 
-        public long ServerTime
-        {
+        public long ServerTime {
             get {
-                if (serverTime < 1)
-                {
+                if (serverTime < 1) {
                     // Time has not been set via socket yet.
                     TimeSpan span = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
                     return Convert.ToInt64(span.TotalMilliseconds);
@@ -66,8 +63,7 @@ namespace Nakama
             }
             private set {
                 // Dont let server time go backwards.
-                if ((value - serverTime) > 0)
-                {
+                if ((value - serverTime) > 0) {
                     serverTime = value;
                 }
             }
@@ -79,6 +75,8 @@ namespace Nakama
 
         public bool Trace { get; private set; }
 
+        private Queue<Action> callbackQueue = new Queue<Action>();
+
         private IDictionary<string, KeyValuePair<Action<object>, Action<INError>>> collationIds =
                 new Dictionary<string, KeyValuePair<Action<object>, Action<INError>>>();
 
@@ -86,8 +84,8 @@ namespace Nakama
 
         private INTransport transport;
 
-        private NClient(string serverKey)
-        {
+
+        private NClient(string serverKey) {
             ConnectTimeout = 3000;
             Host = "127.0.0.1";
             Port = 7350;
@@ -111,13 +109,11 @@ namespace Nakama
 
             transport.Logger = Logger;
             transport.Trace = Trace;
-            transport.OnClose += (sender, _) =>
-            {
+            transport.OnClose += (sender, _) => {
                 collationIds.Clear();
                 OnDisconnect.Emit(this, EventArgs.Empty);
             };
-            transport.OnMessage += (sender, m) =>
-            {
+            transport.OnMessage += (sender, m) => {
                 var message = Envelope.Parser.ParseFrom(m.Data);
                 Logger.TraceFormatIf(Trace, "SocketDecoded: {0}", message);
                 onMessage(message);
@@ -126,90 +122,78 @@ namespace Nakama
 
         public void Register(INAuthenticateMessage message,
             Action<INSession> callback,
-            Action<INError> errback)
-        {
+            Action<INError> errback) {
             authenticate("/user/register", message.Payload, Lang, callback, errback);
         }
 
         public void Login(INAuthenticateMessage message,
             Action<INSession> callback,
-            Action<INError> errback)
-        {
+            Action<INError> errback) {
             authenticate("/user/login", message.Payload, Lang, callback, errback);
         }
 
-        public void Connect(INSession session)
-        {
+        public void Connect(INSession session) {
             transport.Connect(getWebsocketUri(session));
         }
 
-        public void Connect(INSession session, Action<bool> callback)
-        {
-            transport.ConnectAsync(getWebsocketUri(session), callback);
+        public void Connect(INSession session, Action<bool> callback) {
+            transport.ConnectAsync(getWebsocketUri(session), completed => callbackQueue.Enqueue(() => callback(completed)));
         }
 
-        public static NClient Default(string serverKey)
-        {
+        public static NClient Default(string serverKey) {
             return new NClient.Builder(serverKey).Build();
         }
 
-        public void Disconnect()
-        {
+        public void Disconnect() {
             transport.Close();
         }
 
-        public void Disconnect(Action callback)
-        {
-            transport.CloseAsync(callback);
+        public void Disconnect(Action callback) {
+            transport.CloseAsync(() => callbackQueue.Enqueue(callback));
         }
 
-        public void Logout()
-        {
-            var payload = new Envelope {Logout = new Logout()};
+        public void Logout() {
+            var payload = new Envelope { Logout = new Logout() };
             var stream = new MemoryStream();
             payload.WriteTo(stream);
             transport.Send(stream.ToArray());
         }
 
-        public void Logout(Action<bool> callback)
-        {
-            var payload = new Envelope {Logout = new Logout()};
+        public void Logout(Action<bool> callback) {
+            var payload = new Envelope { Logout = new Logout() };
             var stream = new MemoryStream();
             payload.WriteTo(stream);
-            transport.SendAsync(stream.ToArray(), (bool completed) =>
-            {
-                callback(completed);
-            });
+            transport.SendAsync(stream.ToArray(), completed => callbackQueue.Enqueue(() => callback(completed)));
         }
 
-        public void Send<T>(INMessage<T> message, Action<T> callback, Action<INError> errback)
-        {
+        public void Send<T>(INMessage<T> message, Action<T> callback, Action<INError> errback) {
             // Set a collation ID to dispatch callbacks on receive
             string collationId = Guid.NewGuid().ToString();
             message.SetCollationId(collationId);
 
             // Track callbacks for message
-            var pair = new KeyValuePair<Action<object>, Action<INError>>((data) =>
-            {
-                callback((T)data);
-            }, errback);
+            var pair = new KeyValuePair<Action<object>, Action<INError>>(data => callbackQueue.Enqueue(() => callback((T)data)), error => callbackQueue.Enqueue(() => errback(error)));
+
             collationIds.Add(collationId, pair);
 
             var stream = new MemoryStream();
             message.Payload.WriteTo(stream);
             Logger.TraceFormatIf(Trace, "SocketWrite: {0}", message.Payload);
-            transport.SendAsync(stream.ToArray(), (bool completed) =>
-            {
-                if (!completed)
-                {
+            transport.SendAsync(stream.ToArray(), (bool completed) => {
+                if (!completed) {
                     // The write may have failed; don't track it
                     collationIds.Remove(collationId);
                 }
             });
         }
 
-        public override string ToString()
-        {
+        public void ProcessCallbacks() {
+            while (callbackQueue.Any()) {
+                callbackQueue.Dequeue()();
+            }
+        }
+
+        public override string ToString() {
             var f = "NClient(ConnectTimeout={0},Host={1},Lang={2},Port={3},ServerKey={4},SSL={5},Timeout={6},Trace={7})";
             return String.Format(f, ConnectTimeout, Host, Lang, Port, ServerKey, SSL, Timeout, Trace);
         }
@@ -218,8 +202,7 @@ namespace Nakama
                                   AuthenticateRequest payload,
                                   string langHeader,
                                   Action<INSession> callback,
-                                  Action<INError> errback)
-        {
+                                  Action<INError> errback) {
             // Add a collation ID for logs
             payload.CollationId = Guid.NewGuid().ToString();
 
@@ -231,18 +214,17 @@ namespace Nakama
             var authHeader = String.Concat("Basic ", Convert.ToBase64String(buffer));
 
             TimeSpan span = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            transport.Post(uri.ToString(), payload, authHeader, langHeader, Timeout, ConnectTimeout, (data) =>
-            {
+
+            transport.Post(uri.ToString(), payload, authHeader, langHeader, Timeout, ConnectTimeout, (data) => {
                 AuthenticateResponse authResponse = AuthenticateResponse.Parser.ParseFrom(data);
                 Logger.TraceFormatIf(Trace, "DecodedResponse={0}", authResponse);
 
-                switch (authResponse.PayloadCase)
-                {
+                switch (authResponse.PayloadCase) {
                     case AuthenticateResponse.PayloadOneofCase.Session:
-                        callback(new NSession(authResponse.Session.Token, System.Convert.ToInt64(span.TotalMilliseconds)));
+                        callbackQueue.Enqueue(() => callback(new NSession(authResponse.Session.Token, System.Convert.ToInt64(span.TotalMilliseconds))));
                         break;
                     case AuthenticateResponse.PayloadOneofCase.Error:
-                        errback(new NError(authResponse.Error));
+                        callbackQueue.Enqueue(() => errback(new NError(authResponse.Error)));
                         break;
                     case AuthenticateResponse.PayloadOneofCase.None:
                         Logger.Error("Received invalid response from server");
@@ -251,14 +233,12 @@ namespace Nakama
                         Logger.Error("Received invalid response from server");
                         break;
                 }
-            }, (e) =>
-            {
+            }, (e) => {
                 errback(new NError(e.Message));
             });
         }
 
-        private string getWebsocketUri(INSession session)
-        {
+        private string getWebsocketUri(INSession session) {
             // Init base WebSocket connection
             var scheme = (SSL) ? "wss" : "ws";
             var bUri = new UriBuilder(scheme, Host, unchecked((int)Port), "api");
@@ -266,36 +246,30 @@ namespace Nakama
             return bUri.Uri.ToString();
         }
 
-        private void onMessage(Envelope message)
-        {
+        private void onMessage(Envelope message) {
             // Handle realtime messages
-            switch (message.PayloadCase)
-            {
+            switch (message.PayloadCase) {
                 case Envelope.PayloadOneofCase.Heartbeat:
                     ServerTime = message.Heartbeat.Timestamp;
                     return;
                 case Envelope.PayloadOneofCase.MatchData:
-                    if (OnMatchData != null)
-                    {
-                        OnMatchData(this, new NMatchDataEventArgs(new NMatchData(message.MatchData)));
+                    if (OnMatchData != null) {
+                        callbackQueue.Enqueue(() => OnMatchData(this, new NMatchDataEventArgs(new NMatchData(message.MatchData))));
                     }
                     return;
                 case Envelope.PayloadOneofCase.MatchPresence:
-                    if (OnMatchPresence != null)
-                    {
-                        OnMatchPresence(this, new NMatchPresenceEventArgs(new NMatchPresence(message.MatchPresence)));
+                    if (OnMatchPresence != null) {
+                        callbackQueue.Enqueue(() => OnMatchPresence(this, new NMatchPresenceEventArgs(new NMatchPresence(message.MatchPresence))));
                     }
                     return;
                 case Envelope.PayloadOneofCase.TopicMessage:
-                    if (OnTopicMessage != null)
-                    {
-                        OnTopicMessage(this, new NTopicMessageEventArgs(new NTopicMessage(message.TopicMessage)));
+                    if (OnTopicMessage != null) {
+                        callbackQueue.Enqueue(() => OnTopicMessage(this, new NTopicMessageEventArgs(new NTopicMessage(message.TopicMessage))));
                     }
                     return;
                 case Envelope.PayloadOneofCase.TopicPresence:
-                    if (OnTopicPresence != null)
-                    {
-                        OnTopicPresence(this, new NTopicPresenceEventArgs(new NTopicPresence(message.TopicPresence)));
+                    if (OnTopicPresence != null) {
+                        callbackQueue.Enqueue(() => OnTopicPresence(this, new NTopicPresenceEventArgs(new NTopicPresence(message.TopicPresence))));
                     }
                     return;
             }
@@ -304,29 +278,24 @@ namespace Nakama
             var pair = collationIds[collationId];
             collationIds.Remove(collationId);
 
-            switch (message.PayloadCase)
-            {
+            switch (message.PayloadCase) {
                 case Envelope.PayloadOneofCase.None:
                     pair.Key(true);
                     break;
                 case Envelope.PayloadOneofCase.Error:
                     var error = new NError(message.Error);
-                    if (collationId != null)
-                    {
+                    if (collationId != null) {
                         pair.Value(error);
                     }
-                    else
-                    {
-                        if (OnError != null)
-                        {
-                            OnError(this, new NErrorEventArgs(error));
+                    else {
+                        if (OnError != null) {
+                            callbackQueue.Enqueue(() => OnError(this, new NErrorEventArgs(error)));
                         }
                     }
                     break;
                 case Envelope.PayloadOneofCase.Friends:
                     var friends = new List<INFriend>();
-                    foreach (var friend in message.Friends.Friends)
-                    {
+                    foreach (var friend in message.Friends.Friends) {
                         friends.Add(new NFriend(friend));
                     }
                     pair.Key(new NResultSet<INFriend>(friends, null));
@@ -336,16 +305,14 @@ namespace Nakama
                     break;
                 case Envelope.PayloadOneofCase.GroupUsers:
                     var groupUsers = new List<INGroupUser>();
-                    foreach (var groupUser in message.GroupUsers.Users)
-                    {
+                    foreach (var groupUser in message.GroupUsers.Users) {
                         groupUsers.Add(new NGroupUser(groupUser));
                     }
                     pair.Key(new NResultSet<INGroupUser>(groupUsers, null));
                     break;
                 case Envelope.PayloadOneofCase.Groups:
                     var groups = new List<INGroup>();
-                    foreach (var group in message.Groups.Groups)
-                    {
+                    foreach (var group in message.Groups.Groups) {
                         groups.Add(new NGroup(group));
                     }
                     pair.Key(new NResultSet<INGroup>(groups, new NCursor(message.Groups.Cursor.ToByteArray())));
@@ -358,16 +325,14 @@ namespace Nakama
                     break;
                 case Envelope.PayloadOneofCase.StorageKey:
                     var keys = new List<INStorageKey>();
-                    foreach (var key in message.StorageKey.Keys)
-                    {
+                    foreach (var key in message.StorageKey.Keys) {
                         keys.Add(new NStorageKey(key));
                     }
                     pair.Key(new NResultSet<INStorageKey>(keys, null));
                     break;
                 case Envelope.PayloadOneofCase.StorageData:
                     var storageData = new List<INStorageData>();
-                    foreach (var data in message.StorageData.Data)
-                    {
+                    foreach (var data in message.StorageData.Data) {
                         storageData.Add(new NStorageData(data));
                     }
                     pair.Key(new NResultSet<INStorageData>(storageData, null));
@@ -380,8 +345,7 @@ namespace Nakama
                     break;
                 case Envelope.PayloadOneofCase.TopicMessages:
                     var topicMessages = new List<INTopicMessage>();
-                    foreach (var topicMessage in message.TopicMessages.Messages)
-                    {
+                    foreach (var topicMessage in message.TopicMessages.Messages) {
                         topicMessages.Add(new NTopicMessage(topicMessage));
                     }
                     pair.Key(new NResultSet<INTopicMessage>(topicMessages,
@@ -389,16 +353,14 @@ namespace Nakama
                     break;
                 case Envelope.PayloadOneofCase.Users:
                     var users = new List<INUser>();
-                    foreach (var user in message.Users.Users)
-                    {
+                    foreach (var user in message.Users.Users) {
                         users.Add(new NUser(user));
                     }
                     pair.Key(new NResultSet<INUser>(users, null));
                     break;
                 case Envelope.PayloadOneofCase.Leaderboards:
                     var leaderboards = new List<INLeaderboard>();
-                    foreach (var leaderboard in message.Leaderboards.Leaderboards)
-                    {
+                    foreach (var leaderboard in message.Leaderboards.Leaderboards) {
                         leaderboards.Add(new NLeaderboard(leaderboard));
                     }
                     pair.Key(new NResultSet<INLeaderboard>(leaderboards, new NCursor(message.Leaderboards.Cursor.ToByteArray())));
@@ -408,8 +370,7 @@ namespace Nakama
                     break;
                 case Envelope.PayloadOneofCase.LeaderboardRecords:
                     var leaderboardRecords = new List<INLeaderboardRecord>();
-                    foreach (var leaderboardRecord in message.LeaderboardRecords.Records)
-                    {
+                    foreach (var leaderboardRecord in message.LeaderboardRecords.Records) {
                         leaderboardRecords.Add(new NLeaderboardRecord(leaderboardRecord));
                     }
                     pair.Key(new NResultSet<INLeaderboardRecord>(leaderboardRecords, new NCursor(message.LeaderboardRecords.Cursor.ToByteArray())));
@@ -420,67 +381,56 @@ namespace Nakama
             }
         }
 
-        public class Builder
-        {
+        public class Builder {
             private NClient client;
 
-            public Builder(string serverKey)
-            {
+            public Builder(string serverKey) {
                 client = new NClient(serverKey);
             }
 
-            public Builder ConnectTimeout(uint connectTimeout)
-            {
+            public Builder ConnectTimeout(uint connectTimeout) {
                 client.ConnectTimeout = connectTimeout;
                 return this;
             }
 
-            public Builder Host(string host)
-            {
+            public Builder Host(string host) {
                 client.Host = host;
                 return this;
             }
 
-            public Builder Lang(string lang)
-            {
+            public Builder Lang(string lang) {
                 client.Lang = lang;
                 return this;
             }
 
-            public Builder Logger(INLogger logger)
-            {
+            public Builder Logger(INLogger logger) {
                 client.Logger = logger;
                 client.transport.Logger = logger;
                 return this;
             }
 
-            public Builder Port(uint port)
-            {
+            public Builder Port(uint port) {
                 client.Port = port;
                 return this;
             }
 
-            public Builder SSL(bool enable)
-            {
+            public Builder SSL(bool enable) {
                 client.SSL = enable;
                 return this;
             }
 
-            public Builder Timeout(uint timeout)
-            {
+            public Builder Timeout(uint timeout) {
                 client.Timeout = timeout;
                 return this;
             }
 
-            public Builder Trace(bool enable)
-            {
+            public Builder Trace(bool enable) {
                 client.Trace = enable;
                 client.transport.Trace = enable;
                 return this;
             }
 
-            public NClient Build()
-            {
+            public NClient Build() {
                 // Clone object so builder now operates on new copy.
                 var original = client;
                 client = new NClient(original.ServerKey);

--- a/Nakama/NClient.cs
+++ b/Nakama/NClient.cs
@@ -26,8 +26,10 @@ using System.Threading;
 using Google.Protobuf;
 using WebSocketSharp;
 
-namespace Nakama {
-    public class NClient : INClient {
+namespace Nakama
+{
+    public class NClient : INClient
+    {
         public uint ConnectTimeout { get; private set; }
 
         public string Host { get; private set; }
@@ -52,9 +54,11 @@ namespace Nakama {
 
         public string ServerKey { get; private set; }
 
-        public long ServerTime {
+        public long ServerTime
+        {
             get {
-                if (serverTime < 1) {
+                if (serverTime < 1)
+                {
                     // Time has not been set via socket yet.
                     TimeSpan span = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
                     return Convert.ToInt64(span.TotalMilliseconds);
@@ -63,7 +67,8 @@ namespace Nakama {
             }
             private set {
                 // Dont let server time go backwards.
-                if ((value - serverTime) > 0) {
+                if ((value - serverTime) > 0)
+                {
                     serverTime = value;
                 }
             }
@@ -84,8 +89,8 @@ namespace Nakama {
 
         private INTransport transport;
 
-
-        private NClient(string serverKey) {
+        private NClient(string serverKey)
+        {
             ConnectTimeout = 3000;
             Host = "127.0.0.1";
             Port = 7350;
@@ -109,11 +114,13 @@ namespace Nakama {
 
             transport.Logger = Logger;
             transport.Trace = Trace;
-            transport.OnClose += (sender, _) => {
+            transport.OnClose += (sender, _) =>
+            {
                 collationIds.Clear();
                 OnDisconnect.Emit(this, EventArgs.Empty);
             };
-            transport.OnMessage += (sender, m) => {
+            transport.OnMessage += (sender, m) =>
+            {
                 var message = Envelope.Parser.ParseFrom(m.Data);
                 Logger.TraceFormatIf(Trace, "SocketDecoded: {0}", message);
                 onMessage(message);
@@ -122,51 +129,61 @@ namespace Nakama {
 
         public void Register(INAuthenticateMessage message,
             Action<INSession> callback,
-            Action<INError> errback) {
+            Action<INError> errback)
+        {
             authenticate("/user/register", message.Payload, Lang, callback, errback);
         }
 
         public void Login(INAuthenticateMessage message,
             Action<INSession> callback,
-            Action<INError> errback) {
+            Action<INError> errback)
+        {
             authenticate("/user/login", message.Payload, Lang, callback, errback);
         }
 
-        public void Connect(INSession session) {
+        public void Connect(INSession session)
+        {
             transport.Connect(getWebsocketUri(session));
         }
 
-        public void Connect(INSession session, Action<bool> callback) {
+        public void Connect(INSession session, Action<bool> callback)
+        {
             transport.ConnectAsync(getWebsocketUri(session), completed => callbackQueue.Enqueue(() => callback(completed)));
         }
 
-        public static NClient Default(string serverKey) {
+        public static NClient Default(string serverKey)
+        {
             return new NClient.Builder(serverKey).Build();
         }
 
-        public void Disconnect() {
+        public void Disconnect()
+        {
             transport.Close();
         }
 
-        public void Disconnect(Action callback) {
+        public void Disconnect(Action callback)
+        {
             transport.CloseAsync(() => callbackQueue.Enqueue(callback));
         }
 
-        public void Logout() {
-            var payload = new Envelope { Logout = new Logout() };
+        public void Logout()
+        {
+            var payload = new Envelope {Logout = new Logout()};
             var stream = new MemoryStream();
             payload.WriteTo(stream);
             transport.Send(stream.ToArray());
         }
 
-        public void Logout(Action<bool> callback) {
-            var payload = new Envelope { Logout = new Logout() };
+        public void Logout(Action<bool> callback)
+        {
+            var payload = new Envelope {Logout = new Logout()};
             var stream = new MemoryStream();
             payload.WriteTo(stream);
             transport.SendAsync(stream.ToArray(), completed => callbackQueue.Enqueue(() => callback(completed)));
         }
 
-        public void Send<T>(INMessage<T> message, Action<T> callback, Action<INError> errback) {
+        public void Send<T>(INMessage<T> message, Action<T> callback, Action<INError> errback)
+        {
             // Set a collation ID to dispatch callbacks on receive
             string collationId = Guid.NewGuid().ToString();
             message.SetCollationId(collationId);
@@ -179,21 +196,26 @@ namespace Nakama {
             var stream = new MemoryStream();
             message.Payload.WriteTo(stream);
             Logger.TraceFormatIf(Trace, "SocketWrite: {0}", message.Payload);
-            transport.SendAsync(stream.ToArray(), (bool completed) => {
-                if (!completed) {
+            transport.SendAsync(stream.ToArray(), (bool completed) =>
+            {
+                if (!completed)
+                {
                     // The write may have failed; don't track it
                     collationIds.Remove(collationId);
                 }
             });
         }
 
-        public void ProcessCallbacks() {
-            while (callbackQueue.Any()) {
+        public void ProcessCallbacks()
+        {
+            while (callbackQueue.Any())
+            {
                 callbackQueue.Dequeue()();
             }
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             var f = "NClient(ConnectTimeout={0},Host={1},Lang={2},Port={3},ServerKey={4},SSL={5},Timeout={6},Trace={7})";
             return String.Format(f, ConnectTimeout, Host, Lang, Port, ServerKey, SSL, Timeout, Trace);
         }
@@ -202,7 +224,8 @@ namespace Nakama {
                                   AuthenticateRequest payload,
                                   string langHeader,
                                   Action<INSession> callback,
-                                  Action<INError> errback) {
+                                  Action<INError> errback)
+        {
             // Add a collation ID for logs
             payload.CollationId = Guid.NewGuid().ToString();
 
@@ -214,12 +237,13 @@ namespace Nakama {
             var authHeader = String.Concat("Basic ", Convert.ToBase64String(buffer));
 
             TimeSpan span = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-            transport.Post(uri.ToString(), payload, authHeader, langHeader, Timeout, ConnectTimeout, (data) => {
+            transport.Post(uri.ToString(), payload, authHeader, langHeader, Timeout, ConnectTimeout, (data) =>
+            {
                 AuthenticateResponse authResponse = AuthenticateResponse.Parser.ParseFrom(data);
                 Logger.TraceFormatIf(Trace, "DecodedResponse={0}", authResponse);
 
-                switch (authResponse.PayloadCase) {
+                switch (authResponse.PayloadCase)
+                {
                     case AuthenticateResponse.PayloadOneofCase.Session:
                         callbackQueue.Enqueue(() => callback(new NSession(authResponse.Session.Token, System.Convert.ToInt64(span.TotalMilliseconds))));
                         break;
@@ -233,12 +257,14 @@ namespace Nakama {
                         Logger.Error("Received invalid response from server");
                         break;
                 }
-            }, (e) => {
+            }, (e) =>
+            {
                 errback(new NError(e.Message));
             });
         }
 
-        private string getWebsocketUri(INSession session) {
+        private string getWebsocketUri(INSession session)
+        {
             // Init base WebSocket connection
             var scheme = (SSL) ? "wss" : "ws";
             var bUri = new UriBuilder(scheme, Host, unchecked((int)Port), "api");
@@ -246,29 +272,35 @@ namespace Nakama {
             return bUri.Uri.ToString();
         }
 
-        private void onMessage(Envelope message) {
+        private void onMessage(Envelope message)
+        {
             // Handle realtime messages
-            switch (message.PayloadCase) {
+            switch (message.PayloadCase)
+            {
                 case Envelope.PayloadOneofCase.Heartbeat:
                     ServerTime = message.Heartbeat.Timestamp;
                     return;
                 case Envelope.PayloadOneofCase.MatchData:
-                    if (OnMatchData != null) {
+                    if (OnMatchData != null)
+                    {
                         callbackQueue.Enqueue(() => OnMatchData(this, new NMatchDataEventArgs(new NMatchData(message.MatchData))));
                     }
                     return;
                 case Envelope.PayloadOneofCase.MatchPresence:
-                    if (OnMatchPresence != null) {
+                    if (OnMatchPresence != null)
+                    {
                         callbackQueue.Enqueue(() => OnMatchPresence(this, new NMatchPresenceEventArgs(new NMatchPresence(message.MatchPresence))));
                     }
                     return;
                 case Envelope.PayloadOneofCase.TopicMessage:
-                    if (OnTopicMessage != null) {
+                    if (OnTopicMessage != null)
+                    {
                         callbackQueue.Enqueue(() => OnTopicMessage(this, new NTopicMessageEventArgs(new NTopicMessage(message.TopicMessage))));
                     }
                     return;
                 case Envelope.PayloadOneofCase.TopicPresence:
-                    if (OnTopicPresence != null) {
+                    if (OnTopicPresence != null)
+                    {
                         callbackQueue.Enqueue(() => OnTopicPresence(this, new NTopicPresenceEventArgs(new NTopicPresence(message.TopicPresence))));
                     }
                     return;
@@ -278,24 +310,29 @@ namespace Nakama {
             var pair = collationIds[collationId];
             collationIds.Remove(collationId);
 
-            switch (message.PayloadCase) {
+            switch (message.PayloadCase)
+            {
                 case Envelope.PayloadOneofCase.None:
                     pair.Key(true);
                     break;
                 case Envelope.PayloadOneofCase.Error:
                     var error = new NError(message.Error);
-                    if (collationId != null) {
+                    if (collationId != null)
+                    {
                         pair.Value(error);
                     }
-                    else {
-                        if (OnError != null) {
+                    else
+                    {
+                        if (OnError != null)
+                        {
                             callbackQueue.Enqueue(() => OnError(this, new NErrorEventArgs(error)));
                         }
                     }
                     break;
                 case Envelope.PayloadOneofCase.Friends:
                     var friends = new List<INFriend>();
-                    foreach (var friend in message.Friends.Friends) {
+                    foreach (var friend in message.Friends.Friends)
+                    {
                         friends.Add(new NFriend(friend));
                     }
                     pair.Key(new NResultSet<INFriend>(friends, null));
@@ -305,14 +342,16 @@ namespace Nakama {
                     break;
                 case Envelope.PayloadOneofCase.GroupUsers:
                     var groupUsers = new List<INGroupUser>();
-                    foreach (var groupUser in message.GroupUsers.Users) {
+                    foreach (var groupUser in message.GroupUsers.Users)
+                    {
                         groupUsers.Add(new NGroupUser(groupUser));
                     }
                     pair.Key(new NResultSet<INGroupUser>(groupUsers, null));
                     break;
                 case Envelope.PayloadOneofCase.Groups:
                     var groups = new List<INGroup>();
-                    foreach (var group in message.Groups.Groups) {
+                    foreach (var group in message.Groups.Groups)
+                    {
                         groups.Add(new NGroup(group));
                     }
                     pair.Key(new NResultSet<INGroup>(groups, new NCursor(message.Groups.Cursor.ToByteArray())));
@@ -325,14 +364,16 @@ namespace Nakama {
                     break;
                 case Envelope.PayloadOneofCase.StorageKey:
                     var keys = new List<INStorageKey>();
-                    foreach (var key in message.StorageKey.Keys) {
+                    foreach (var key in message.StorageKey.Keys)
+                    {
                         keys.Add(new NStorageKey(key));
                     }
                     pair.Key(new NResultSet<INStorageKey>(keys, null));
                     break;
                 case Envelope.PayloadOneofCase.StorageData:
                     var storageData = new List<INStorageData>();
-                    foreach (var data in message.StorageData.Data) {
+                    foreach (var data in message.StorageData.Data)
+                    {
                         storageData.Add(new NStorageData(data));
                     }
                     pair.Key(new NResultSet<INStorageData>(storageData, null));
@@ -345,7 +386,8 @@ namespace Nakama {
                     break;
                 case Envelope.PayloadOneofCase.TopicMessages:
                     var topicMessages = new List<INTopicMessage>();
-                    foreach (var topicMessage in message.TopicMessages.Messages) {
+                    foreach (var topicMessage in message.TopicMessages.Messages)
+                    {
                         topicMessages.Add(new NTopicMessage(topicMessage));
                     }
                     pair.Key(new NResultSet<INTopicMessage>(topicMessages,
@@ -353,14 +395,16 @@ namespace Nakama {
                     break;
                 case Envelope.PayloadOneofCase.Users:
                     var users = new List<INUser>();
-                    foreach (var user in message.Users.Users) {
+                    foreach (var user in message.Users.Users)
+                    {
                         users.Add(new NUser(user));
                     }
                     pair.Key(new NResultSet<INUser>(users, null));
                     break;
                 case Envelope.PayloadOneofCase.Leaderboards:
                     var leaderboards = new List<INLeaderboard>();
-                    foreach (var leaderboard in message.Leaderboards.Leaderboards) {
+                    foreach (var leaderboard in message.Leaderboards.Leaderboards)
+                    {
                         leaderboards.Add(new NLeaderboard(leaderboard));
                     }
                     pair.Key(new NResultSet<INLeaderboard>(leaderboards, new NCursor(message.Leaderboards.Cursor.ToByteArray())));
@@ -370,7 +414,8 @@ namespace Nakama {
                     break;
                 case Envelope.PayloadOneofCase.LeaderboardRecords:
                     var leaderboardRecords = new List<INLeaderboardRecord>();
-                    foreach (var leaderboardRecord in message.LeaderboardRecords.Records) {
+                    foreach (var leaderboardRecord in message.LeaderboardRecords.Records)
+                    {
                         leaderboardRecords.Add(new NLeaderboardRecord(leaderboardRecord));
                     }
                     pair.Key(new NResultSet<INLeaderboardRecord>(leaderboardRecords, new NCursor(message.LeaderboardRecords.Cursor.ToByteArray())));
@@ -381,56 +426,67 @@ namespace Nakama {
             }
         }
 
-        public class Builder {
+        public class Builder
+        {
             private NClient client;
 
-            public Builder(string serverKey) {
+            public Builder(string serverKey)
+            {
                 client = new NClient(serverKey);
             }
 
-            public Builder ConnectTimeout(uint connectTimeout) {
+            public Builder ConnectTimeout(uint connectTimeout)
+            {
                 client.ConnectTimeout = connectTimeout;
                 return this;
             }
 
-            public Builder Host(string host) {
+            public Builder Host(string host)
+            {
                 client.Host = host;
                 return this;
             }
 
-            public Builder Lang(string lang) {
+            public Builder Lang(string lang)
+            {
                 client.Lang = lang;
                 return this;
             }
 
-            public Builder Logger(INLogger logger) {
+            public Builder Logger(INLogger logger)
+            {
                 client.Logger = logger;
                 client.transport.Logger = logger;
                 return this;
             }
 
-            public Builder Port(uint port) {
+            public Builder Port(uint port)
+            {
                 client.Port = port;
                 return this;
             }
 
-            public Builder SSL(bool enable) {
+            public Builder SSL(bool enable)
+            {
                 client.SSL = enable;
                 return this;
             }
 
-            public Builder Timeout(uint timeout) {
+            public Builder Timeout(uint timeout)
+            {
                 client.Timeout = timeout;
                 return this;
             }
 
-            public Builder Trace(bool enable) {
+            public Builder Trace(bool enable)
+            {
                 client.Trace = enable;
                 client.transport.Trace = enable;
                 return this;
             }
 
-            public NClient Build() {
+            public NClient Build()
+            {
                 // Clone object so builder now operates on new copy.
                 var original = client;
                 client = new NClient(original.ServerKey);


### PR DESCRIPTION
There are many reasons to enable developers to choose when their callbacks are handled. The most obvious being methods in the UnityEngine API must be called from the main thread. I am not claiming this is the best way to handle this simply putting forward a starting point for discussion. 