### PR TITLE
Add batch api changes

### DIFF
--- a/Nakama.Tests/LeaderboardTest.cs
+++ b/Nakama.Tests/LeaderboardTest.cs
@@ -146,9 +146,9 @@ namespace Nakama.Tests
                 .Set(score)
                 .Build();
 
-            client.Send(message, (INLeaderboardRecord result) =>
+            client.Send(message, (INResultSet<INLeaderboardRecord> results) =>
             {
-                res = result;
+                res = results.Results[0];
                 evt.Set();
             }, _ => {
                 evt.Set();

--- a/Nakama.Tests/MatchTest.cs
+++ b/Nakama.Tests/MatchTest.cs
@@ -131,7 +131,7 @@ namespace Nakama.Tests
 
             client1.Send(NMatchCreateMessage.Default(), (INMatch match) =>
             {
-                client2.Send(NMatchJoinMessage.Default(match.Id), (INMatch match2) =>
+                client2.Send(NMatchJoinMessage.Default(match.Id), (INResultSet<INMatch> match2) =>
                 {
                     evt.Set();
                 }, (INError err) =>
@@ -176,7 +176,7 @@ namespace Nakama.Tests
                 joinedUserId = args.MatchPresence.Join[0].UserId;
                 evt2.Set();
             };
-            client2.Send(NMatchJoinMessage.Default(m.Id), (INMatch match) =>
+            client2.Send(NMatchJoinMessage.Default(m.Id), (INResultSet<INMatch> match) =>
             {
                 // No action.
             }, (INError err) =>
@@ -199,7 +199,7 @@ namespace Nakama.Tests
             client1.Send(NMatchCreateMessage.Default(), (INMatch match) =>
             {
                 m = match;
-                client2.Send(NMatchJoinMessage.Default(m.Id), (INMatch match2) =>
+                client2.Send(NMatchJoinMessage.Default(m.Id), (INResultSet<INMatch> match2) =>
                 {
                     evt1.Set();
                 }, (INError err) =>
@@ -246,7 +246,7 @@ namespace Nakama.Tests
             client1.Send(NMatchCreateMessage.Default(), (INMatch match) =>
             {
                 m = match;
-                client2.Send(NMatchJoinMessage.Default(match.Id), (INMatch match2) =>
+                client2.Send(NMatchJoinMessage.Default(match.Id), (INResultSet<INMatch> match2) =>
                 {
                     evt1.Set();
                 }, (INError err) =>
@@ -337,8 +337,9 @@ namespace Nakama.Tests
             client1.Send(NMatchCreateMessage.Default(), (INMatch match) =>
             {
                 m = match;
-                client2.Send(NMatchJoinMessage.Default(match.Id), (INMatch match2) =>
+                client2.Send(NMatchJoinMessage.Default(match.Id), (INResultSet<INMatch> matches2) =>
                 {
+                    var match2 = matches2.Results[0];
                     foreach (var up in match2.Presence)
                     {
                         if (up.UserId.SequenceEqual(userId2))

--- a/Nakama.Tests/MatchmakeTest.cs
+++ b/Nakama.Tests/MatchmakeTest.cs
@@ -239,18 +239,18 @@ namespace Nakama.Tests
             INMatch m2 = null;
             INError error1m = null;
             INError error2m = null;
-            client1.Send(NMatchJoinMessage.Default(res1.Token), (INMatch match) =>
+            client1.Send(NMatchJoinMessage.Default(res1.Token), (INResultSet<INMatch> matches) =>
             {
-                m1 = match;
+                m1 = matches.Results[0];
                 evt1m.Set();
             }, (INError err) =>
             {
                 error1m = err;
                 evt1m.Set();
             });
-            client2.Send(NMatchJoinMessage.Default(res2.Token), (INMatch match) =>
+            client2.Send(NMatchJoinMessage.Default(res2.Token), (INResultSet<INMatch> matches) =>
             {
-                m2 = match;
+                m2 = matches.Results[0];
                 evt2m.Set();
             }, (INError err) =>
             {

--- a/Nakama.Tests/SimpleMetadataTest.cs
+++ b/Nakama.Tests/SimpleMetadataTest.cs
@@ -32,12 +32,8 @@ namespace Nakama
         {
             var request  = setupRequest();
             var response = (HttpWebResponse) request.GetResponse();
-            var stream = response.GetResponseStream();
-            var reader = new StreamReader(stream, Encoding.UTF8);
-            var result = reader.ReadToEnd();
             response.Close();
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, response.StatusDescription);
-            Assert.That(result, Contains.Substring("status"));
         }
 
         [Test]
@@ -104,7 +100,7 @@ namespace Nakama
 
         private static HttpWebRequest setupRequest()
         {
-            return setupRequest("/v0/health");
+            return setupRequest("/v0/info");
         }
 
         private static HttpWebRequest setupRequest(string path)

--- a/Nakama.Tests/TopicTest.cs
+++ b/Nakama.Tests/TopicTest.cs
@@ -83,7 +83,7 @@ namespace Nakama.Tests
             INError error = null;
 
             var message = new NTopicJoinMessage.Builder().TopicRoom(Encoding.UTF8.GetBytes("test-room")).Build();
-            client1.Send(message, (INTopic topic) =>
+            client1.Send(message, (INResultSet<INTopic> topics) =>
             {
                 evt.Set();
             }, (INError err) =>
@@ -103,8 +103,9 @@ namespace Nakama.Tests
             INError error = null;
 
             var message = new NTopicJoinMessage.Builder().TopicRoom(Encoding.UTF8.GetBytes("test-room")).Build();
-            client1.Send(message, (INTopic topic) =>
+            client1.Send(message, (INResultSet<INTopic> topics) =>
             {
+                var topic = topics.Results[0];
                 client1.Send(NTopicLeaveMessage.Default(topic.Topic), (bool complete) =>
                 {
                     evt.Set();
@@ -130,7 +131,7 @@ namespace Nakama.Tests
             ManualResetEvent evt1 = new ManualResetEvent(false);
             byte[] room = Encoding.UTF8.GetBytes("test-room");
             var message = new NTopicJoinMessage.Builder().TopicRoom(room).Build();
-            client1.Send(message, (INTopic topic) =>
+            client1.Send(message, (INResultSet<INTopic> topics) =>
             {
                 evt1.Set();
             }, (INError err) =>
@@ -148,7 +149,7 @@ namespace Nakama.Tests
                 joinUserId = args.TopicPresence.Join[0].UserId;
                 evt2.Set();
             };
-            client2.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INTopic topic) =>
+            client2.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INResultSet<INTopic> topic) =>
             {
                 // No action.
             }, (INError err) =>
@@ -169,10 +170,10 @@ namespace Nakama.Tests
             ManualResetEvent evt1 = new ManualResetEvent(false);
             byte[] room = Encoding.UTF8.GetBytes("test-room");
             INTopic topic = null;
-            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INTopic topic1) =>
+            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INResultSet<INTopic> topics1) =>
             {
-                topic = topic1;
-                client2.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INTopic topic2) =>
+                topic = topics1.Results[0];
+                client2.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INResultSet<INTopic> topics2) =>
                 {
                     evt1.Set();
                 }, (INError err) =>
@@ -217,9 +218,9 @@ namespace Nakama.Tests
 
             INTopic topic = null;
             ManualResetEvent evt1 = new ManualResetEvent(false);
-            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(Encoding.UTF8.GetBytes("test-room")).Build(), (INTopic top) =>
+            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(Encoding.UTF8.GetBytes("test-room")).Build(), (INResultSet<INTopic> topics) =>
             {
-                topic = top;
+                topic = topics.Results[0];
                 client1.Send(NTopicLeaveMessage.Default(topic.Topic), (bool complete) =>
                 {
                     evt1.Set();
@@ -258,10 +259,10 @@ namespace Nakama.Tests
             ManualResetEvent evt1 = new ManualResetEvent(false);
             byte[] room = Encoding.UTF8.GetBytes("test-room");
             INTopic topic = null;
-            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INTopic topic1) =>
+            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INResultSet<INTopic> topics1) =>
             {
-                topic = topic1;
-                client2.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INTopic topic2) =>
+                topic = topics1.Results[0];
+                client2.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INResultSet<INTopic> topics2) =>
                 {
                     evt1.Set();
                 }, (INError err) =>
@@ -323,9 +324,9 @@ namespace Nakama.Tests
             ManualResetEvent evt1 = new ManualResetEvent(false);
             byte[] room = Encoding.UTF8.GetBytes("history-room");
             INTopic t = null;
-            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INTopic topic) =>
+            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INResultSet<INTopic> topics) =>
             {
-                t = topic;
+                t = topics.Results[0];
                 evt1.Set();
             }, (INError err) =>
             {
@@ -388,9 +389,9 @@ namespace Nakama.Tests
             byte[] room = Encoding.UTF8.GetBytes("test-room-handle-update");
             INTopic topic = null;
 
-            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INTopic topic1) =>
+            client1.Send(new NTopicJoinMessage.Builder().TopicRoom(room).Build(), (INResultSet<INTopic> topics1) =>
             {
-                topic = topic1;
+                topic = topics1.Results[0];
 
                 client1.OnTopicPresence += (object source, NTopicPresenceEventArgs args) =>
                 {

--- a/Nakama/NFriendAddMessage.cs
+++ b/Nakama/NFriendAddMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,12 +31,24 @@ namespace Nakama
 
         private NFriendAddMessage(byte[] id)
         {
-            payload = new Envelope {FriendAdd = new TFriendAdd {UserId = ByteString.CopyFrom(id)}};
+            payload = new Envelope {FriendsAdd = new TFriendsAdd { Friends =
+            {
+                new List<TFriendsAdd.Types.FriendsAdd>
+                {
+                    new TFriendsAdd.Types.FriendsAdd {UserId = ByteString.CopyFrom(id)}
+                }
+            }}};
         }
         
         private NFriendAddMessage(string handle)
         {
-            payload = new Envelope {FriendAdd = new TFriendAdd {Handle = handle}};
+            payload = new Envelope {FriendsAdd = new TFriendsAdd { Friends =
+            {
+                new List<TFriendsAdd.Types.FriendsAdd>
+                {
+                    new TFriendsAdd.Types.FriendsAdd {Handle = handle}
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -45,7 +58,22 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NFriendAddMessage(UserId={0}, Handle={1})", payload.FriendAdd.UserId, payload.FriendAdd.Handle);
+            var p = payload.FriendsAdd;
+            string ids = "";
+            string handles = "";
+            foreach (var f in p.Friends)
+            {
+                switch (f.IdCase)
+                {
+                    case TFriendsAdd.Types.FriendsAdd.IdOneofCase.Handle:
+                        handles += "handle=" + f.Handle + ",";
+                        break;
+                    case TFriendsAdd.Types.FriendsAdd.IdOneofCase.UserId:
+                        ids += "id=" + f.UserId + ",";
+                        break;
+                }
+            }
+            return String.Format("NFriendsAddMessage(UserIds={0}, Handles={1})", ids, handles);
         }
 
         public static NFriendAddMessage Default(byte[] id)

--- a/Nakama/NFriendBlockMessage.cs
+++ b/Nakama/NFriendBlockMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,7 +31,13 @@ namespace Nakama
 
         private NFriendBlockMessage(byte[] id)
         {
-            payload = new Envelope {FriendBlock = new TFriendBlock {UserId = ByteString.CopyFrom(id)}};
+            payload = new Envelope {FriendsBlock = new TFriendsBlock { UserIds =
+            {
+                new List<ByteString>
+                {
+                    ByteString.CopyFrom(id)
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -40,7 +47,13 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NFriendBlockMessage(Id={0})", payload.FriendBlock.UserId);
+            var p = payload.FriendsBlock;
+            string ids = "";
+            foreach (var f in p.UserIds)
+            {
+                ids += "id=" + f + ",";
+            }
+            return String.Format("NFriendsBlockMessage(UserIds={0)", ids);   
         }
 
         public static NFriendBlockMessage Default(byte[] id)

--- a/Nakama/NFriendRemoveMessage.cs
+++ b/Nakama/NFriendRemoveMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,7 +31,13 @@ namespace Nakama
 
         private NFriendRemoveMessage(byte[] id)
         {
-            payload = new Envelope {FriendRemove = new TFriendRemove {UserId = ByteString.CopyFrom(id)}};
+            payload = new Envelope {FriendsRemove = new TFriendsRemove { UserIds =
+            {
+                new List<ByteString>
+                {
+                    ByteString.CopyFrom(id)
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -40,7 +47,13 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NFriendRemoveMessage(UserId={0})", payload.FriendRemove.UserId);
+            var p = payload.FriendsRemove;
+            string ids = "";
+            foreach (var f in p.UserIds)
+            {
+                ids += "id=" + f + ",";
+            }
+            return String.Format("NFriendsBlockMessage(UserIds={0)", ids);   
         }
 
         public static NFriendRemoveMessage Default(byte[] id)

--- a/Nakama/NGroupAddUserMessage.cs
+++ b/Nakama/NGroupAddUserMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,9 +31,17 @@ namespace Nakama
 
         private NGroupAddUserMessage(byte[] groupId, byte[] userId)
         {
-            payload = new Envelope {GroupUserAdd = new TGroupUserAdd()};
-            payload.GroupUserAdd.GroupId = ByteString.CopyFrom(groupId);
-            payload.GroupUserAdd.UserId = ByteString.CopyFrom(userId);
+            payload = new Envelope {GroupUsersAdd = new TGroupUsersAdd { GroupUsers =
+            {
+                new List<TGroupUsersAdd.Types.GroupUserAdd>
+                {
+                    new TGroupUsersAdd.Types.GroupUserAdd
+                    {
+                        UserId = ByteString.CopyFrom(userId),
+                        GroupId = ByteString.CopyFrom(groupId)
+                    }
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -42,7 +51,13 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NGroupAddUserMessage(GroupId={0},UserId={1})", payload.GroupUserAdd.GroupId, payload.GroupUserAdd.UserId);
+            var p = payload.GroupUsersAdd;
+            string output = "";
+            foreach (var g in p.GroupUsers)
+            {
+                output += String.Format("(UserId={0},GroupId={1}),", g.UserId, g.GroupId);
+            }
+            return String.Format("NFriendsAddMessage({0})", output);
         }
 
         public static NGroupAddUserMessage Default(byte[] groupId, byte[] userId)

--- a/Nakama/NGroupCreateMessage.cs
+++ b/Nakama/NGroupCreateMessage.cs
@@ -15,6 +15,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Security;
 using System.Text;
 using Google.Protobuf;
 
@@ -31,14 +33,21 @@ namespace Nakama
 
         private NGroupCreateMessage()
         {
-            payload = new Envelope {GroupCreate = new TGroupCreate()};
+            payload = new Envelope {GroupsCreate = new TGroupsCreate { Groups =
+            {
+                new List<TGroupsCreate.Types.GroupCreate>()
+            }}};   
         }
 
         private NGroupCreateMessage(string name)
         {
-            var request = new TGroupCreate();
-            request.Name = name;
-            payload = new Envelope {GroupCreate = request};
+            payload = new Envelope {GroupsCreate = new TGroupsCreate { Groups =
+            {
+                new List<TGroupsCreate.Types.GroupCreate>
+                {
+                    new TGroupsCreate.Types.GroupCreate {Name = name}
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -49,8 +58,12 @@ namespace Nakama
         public override string ToString()
         {
             var f = "NGroupCreateMessage(Name={0},Description={1},AvatarUrl={2},Lang={3},Metadata={4},Private={5})";
-            var p = payload.GroupCreate;
-            return String.Format(f, p.Name, p.Description, p.AvatarUrl, p.Lang, p.Metadata, p.Private);
+            var output = "";
+            foreach (var p in payload.GroupsCreate.Groups)
+            {
+                output += String.Format(f, p.Name, p.Description, p.AvatarUrl, p.Lang, p.Metadata, p.Private); 
+            }
+            return output;
         }
 
         public class Builder
@@ -64,31 +77,31 @@ namespace Nakama
 
             public Builder Description(string description)
             {
-                message.payload.GroupCreate.Description = description;
+                message.payload.GroupsCreate.Groups[0].Description = description;
                 return this;
             }
 
             public Builder AvatarUrl(string avatarUrl)
             {
-                message.payload.GroupCreate.AvatarUrl = avatarUrl;
+                message.payload.GroupsCreate.Groups[0].AvatarUrl = avatarUrl;
                 return this;
             }
 
             public Builder Lang(string lang)
             {
-                message.payload.GroupCreate.Lang = lang;
+                message.payload.GroupsCreate.Groups[0].Lang = lang;
                 return this;
             }
 
             public Builder Metadata(byte[] metadata)
             {
-                message.payload.GroupCreate.Metadata = ByteString.CopyFrom(metadata);
+                message.payload.GroupsCreate.Groups[0].Metadata = ByteString.CopyFrom(metadata);
                 return this;
             }
 
             public Builder Private(bool privateGroup)
             {
-                message.payload.GroupCreate.Private = privateGroup;
+                message.payload.GroupsCreate.Groups[0].Private = privateGroup;
                 return this;
             }
 
@@ -97,7 +110,7 @@ namespace Nakama
                 // Clone object so builder now operates on new copy.
                 var original = message;
                 message = new NGroupCreateMessage();
-                message.payload.GroupCreate = new TGroupCreate(original.payload.GroupCreate);
+                message.payload.GroupsCreate = new TGroupsCreate(original.payload.GroupsCreate);
                 return original;
             }
         }

--- a/Nakama/NGroupJoinMessage.cs
+++ b/Nakama/NGroupJoinMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,8 +31,13 @@ namespace Nakama
 
         private NGroupJoinMessage(byte[] groupId)
         {
-            payload = new Envelope {GroupJoin = new TGroupJoin()};
-            payload.GroupJoin.GroupId = ByteString.CopyFrom(groupId);
+            payload = new Envelope {GroupsJoin = new TGroupsJoin {GroupIds =
+            {
+                new List<ByteString>
+                {
+                    ByteString.CopyFrom(groupId)
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -41,7 +47,12 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NGroupJoinMessage(GroupId={0})", payload.GroupJoin.GroupId);
+            var output = "";
+            foreach (var id in payload.GroupsJoin.GroupIds)
+            {
+                output += id + ", ";
+            }
+            return String.Format("NGroupJoinMessage(GroupIds={0})", output);
         }
 
         public static NGroupJoinMessage Default(byte[] groupId)

--- a/Nakama/NGroupKickUserMessage.cs
+++ b/Nakama/NGroupKickUserMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,9 +31,17 @@ namespace Nakama
 
         private NGroupKickUserMessage(byte[] groupId, byte[] userId)
         {
-            payload = new Envelope {GroupUserKick = new TGroupUserKick()};
-            payload.GroupUserKick.GroupId = ByteString.CopyFrom(groupId);
-            payload.GroupUserKick.UserId = ByteString.CopyFrom(userId);
+            payload = new Envelope {GroupUsersKick = new TGroupUsersKick { GroupUsers =
+            {
+                new List<TGroupUsersKick.Types.GroupUserKick>
+                {
+                    new TGroupUsersKick.Types.GroupUserKick
+                    {
+                        UserId = ByteString.CopyFrom(userId),
+                        GroupId = ByteString.CopyFrom(groupId)
+                    }
+                }
+            }}};   
         }
 
         public void SetCollationId(string id)
@@ -42,7 +51,13 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NGroupKickUserMessage(GroupId={0},UserId={1})", payload.GroupUserKick.GroupId, payload.GroupUserKick.UserId);
+            var p = payload.GroupUsersKick;
+            string output = "";
+            foreach (var g in p.GroupUsers)
+            {
+                output += String.Format("(UserId={0},GroupId={1}),", g.UserId, g.GroupId);
+            }
+            return String.Format("NGroupKickUserMessage({0})", output);
         }
 
         public static NGroupKickUserMessage Default(byte[] groupId, byte[] userId)

--- a/Nakama/NGroupLeaveMessage.cs
+++ b/Nakama/NGroupLeaveMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,8 +31,13 @@ namespace Nakama
 
         private NGroupLeaveMessage(byte[] groupId)
         {
-            payload = new Envelope {GroupLeave = new TGroupLeave()};
-            payload.GroupLeave.GroupId = ByteString.CopyFrom(groupId);
+            payload = new Envelope {GroupsLeave = new TGroupsLeave { GroupIds =
+            {
+                new List<ByteString>
+                {
+                    ByteString.CopyFrom(groupId)
+                }
+            }}};   
         }
 
         public void SetCollationId(string id)
@@ -41,7 +47,12 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NGroupLeaveMessage(GroupId={0})", payload.GroupLeave.GroupId);
+            var output = "";
+            foreach (var id in payload.GroupsLeave.GroupIds)
+            {
+                output += id + ", ";
+            }
+            return String.Format("NGroupLeaveMessage(GroupIds={0})", output);
         }
 
         public static NGroupLeaveMessage Default(byte[] groupId)

--- a/Nakama/NGroupPromoteUserMessage.cs
+++ b/Nakama/NGroupPromoteUserMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,9 +31,17 @@ namespace Nakama
 
         private NGroupPromoteUserMessage(byte[] groupId, byte[] userId)
         {
-            payload = new Envelope {GroupUserPromote = new TGroupUserPromote()};
-            payload.GroupUserPromote.GroupId = ByteString.CopyFrom(groupId);
-            payload.GroupUserPromote.UserId = ByteString.CopyFrom(userId);
+            payload = new Envelope {GroupUsersPromote = new TGroupUsersPromote { GroupUsers =
+            {
+                new List<TGroupUsersPromote.Types.GroupUserPromote>
+                {
+                    new TGroupUsersPromote.Types.GroupUserPromote
+                    {
+                        UserId = ByteString.CopyFrom(userId),
+                        GroupId = ByteString.CopyFrom(groupId)
+                    }
+                }
+            }}};     
         }
 
         public void SetCollationId(string id)
@@ -42,7 +51,13 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NGroupPromoteUserMessage(GroupId={0},UserId={1})", payload.GroupUserPromote.GroupId, payload.GroupUserPromote.UserId);
+            var p = payload.GroupUsersKick;
+            string output = "";
+            foreach (var g in p.GroupUsers)
+            {
+                output += String.Format("(UserId={0},GroupId={1}),", g.UserId, g.GroupId);
+            }
+            return String.Format("NGroupPromoteUserMessage({0})", output);
         }
 
         public static NGroupPromoteUserMessage Default(byte[] groupId, byte[] userId)

--- a/Nakama/NGroupRemoveMessage.cs
+++ b/Nakama/NGroupRemoveMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,7 +31,13 @@ namespace Nakama
 
         private NGroupRemoveMessage(byte[] id)
         {
-            payload = new Envelope {GroupRemove = new TGroupRemove {GroupId = ByteString.CopyFrom(id)}};
+            payload = new Envelope {GroupsRemove = new TGroupsRemove { GroupIds =
+            {
+                new List<ByteString>
+                {
+                    ByteString.CopyFrom(id)
+                }
+            }}}; 
         }
 
         public void SetCollationId(string id)
@@ -40,7 +47,12 @@ namespace Nakama
 
         public override string ToString()
         {
-            return String.Format("NGroupRemoveMessage(GroupId={0})", payload.GroupRemove.GroupId);
+            var output = "";
+            foreach (var id in payload.GroupsRemove.GroupIds)
+            {
+                output += id + ", ";
+            }
+            return String.Format("NGroupRemoveMessage(GroupIds={0})", output);
         }
 
         public static NGroupRemoveMessage Default(byte[] id)

--- a/Nakama/NGroupUpdateMessage.cs
+++ b/Nakama/NGroupUpdateMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Google.Protobuf;
 
@@ -31,14 +32,21 @@ namespace Nakama
 
         private NGroupUpdateMessage()
         {
-            payload = new Envelope {GroupUpdate = new TGroupUpdate()};
+            payload = new Envelope {GroupsUpdate = new TGroupsUpdate { Groups =
+            {
+                new List<TGroupsUpdate.Types.GroupUpdate>()
+            }}};
         }
 
         private NGroupUpdateMessage(byte[] groupId)
         {
-            var request = new TGroupUpdate();
-            request.GroupId = ByteString.CopyFrom(groupId);
-            payload = new Envelope {GroupUpdate = request};
+            payload = new Envelope {GroupsUpdate = new TGroupsUpdate { Groups =
+            {
+                new List<TGroupsUpdate.Types.GroupUpdate>
+                {
+                    new TGroupsUpdate.Types.GroupUpdate {GroupId = ByteString.CopyFrom(groupId)}
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -49,8 +57,12 @@ namespace Nakama
         public override string ToString()
         {
             var f = "NGroupUpdateMessage(GroupId={0},Name={1},Description={2},AvatarUrl={3},Lang={4},Metadata={5},Private={6})";
-            var p = payload.GroupUpdate;
-            return String.Format(f, p.GroupId, p.Name, p.Description, p.AvatarUrl, p.Lang, p.Metadata, p.Private);
+            var output = "";
+            foreach (var p in payload.GroupsUpdate.Groups)
+            {
+                output += String.Format(f, p.GroupId, p.Name, p.Description, p.AvatarUrl, p.Lang, p.Metadata, p.Private); 
+            }
+            return output;
         }
 
         public class Builder
@@ -64,37 +76,37 @@ namespace Nakama
 
             public Builder Name(string name)
             {
-                message.payload.GroupUpdate.Name = name;
+                message.payload.GroupsUpdate.Groups[0].Name = name;
                 return this;
             }
 
             public Builder Description(string description)
             {
-                message.payload.GroupUpdate.Description = description;
+                message.payload.GroupsUpdate.Groups[0].Description = description;
                 return this;
             }
 
             public Builder AvatarUrl(string avatarUrl)
             {
-                message.payload.GroupUpdate.AvatarUrl = avatarUrl;
+                message.payload.GroupsUpdate.Groups[0].AvatarUrl = avatarUrl;
                 return this;
             }
 
             public Builder Lang(string lang)
             {
-                message.payload.GroupUpdate.Lang = lang;
+                message.payload.GroupsUpdate.Groups[0].Lang = lang;
                 return this;
             }
 
             public Builder Metadata(byte[] metadata)
             {
-                message.payload.GroupUpdate.Metadata = ByteString.CopyFrom(metadata);
+                message.payload.GroupsUpdate.Groups[0].Metadata = ByteString.CopyFrom(metadata);
                 return this;
             }
 
             public Builder Private(bool privateGroup)
             {
-                message.payload.GroupUpdate.Private = privateGroup;
+                message.payload.GroupsUpdate.Groups[0].Private = privateGroup;
                 return this;
             }
 
@@ -103,7 +115,7 @@ namespace Nakama
                 // Clone object so builder now operates on new copy.
                 var original = message;
                 message = new NGroupUpdateMessage();
-                message.payload.GroupUpdate = new TGroupUpdate(original.payload.GroupUpdate);
+                message.payload.GroupsUpdate = new TGroupsUpdate(original.payload.GroupsUpdate);
                 return original;
             }
         }

--- a/Nakama/NGroupsFetchMessage.cs
+++ b/Nakama/NGroupsFetchMessage.cs
@@ -31,24 +31,26 @@ namespace Nakama
 
         private NGroupsFetchMessage(params byte[][] ids)
         {
-            var request = new TGroupsFetch();
-            request.GroupIds = new TGroupsFetch.Types.GroupIds();
+            var groups = new List<TGroupsFetch.Types.GroupFetch>();
             foreach (var id in ids)
             {
-                request.GroupIds.GroupIds_.Add(ByteString.CopyFrom(id));
+                var g = new TGroupsFetch.Types.GroupFetch();
+                g.GroupId = ByteString.CopyFrom(id);
+                groups.Add(g);
             }
-            payload = new Envelope {GroupsFetch = request};
+            payload = new Envelope {GroupsFetch = new TGroupsFetch { Groups = {groups}}};    
         }
 
         private NGroupsFetchMessage(params string[] names)
         {
-            var request = new TGroupsFetch();
-            request.Names = new TGroupsFetch.Types.Names();
+            var groups = new List<TGroupsFetch.Types.GroupFetch>();
             foreach (var name in names)
             {
-                request.Names.Names_.Add(name);
+                var g = new TGroupsFetch.Types.GroupFetch();
+                g.Name = name;
+                groups.Add(g);
             }
-            payload = new Envelope {GroupsFetch = request};
+            payload = new Envelope {GroupsFetch = new TGroupsFetch { Groups = {groups}}};
         }
 
         private NGroupsFetchMessage()
@@ -63,28 +65,22 @@ namespace Nakama
 
         public override string ToString()
         {
-            string output = "";
-            switch (payload.GroupsFetch.SetCase)
+            var p = payload.GroupsFetch;
+            string ids = "";
+            string names = "";
+            foreach (var g in p.Groups)
             {
-                case TGroupsFetch.SetOneofCase.GroupIds:
-                    output += "GroupIds=";
-                    foreach (var id in payload.GroupsFetch.GroupIds.GroupIds_)
-                    {
-                        output += id.ToBase64() + ",";
-                    }
-                    break;
-                case TGroupsFetch.SetOneofCase.Names:
-                    output += "Names=";
-                    foreach (var name in payload.GroupsFetch.Names.Names_)
-                    {
-                        output += name + ",";
-                    }
-                    break;
-                default:
-                    output += "unknown";
-                    break;
+                switch (g.IdCase)
+                {
+                    case TGroupsFetch.Types.GroupFetch.IdOneofCase.Name:
+                        names += "name=" + g.Name + ",";
+                        break;
+                    case TGroupsFetch.Types.GroupFetch.IdOneofCase.GroupId:
+                        ids += "id=" + g.GroupId + ",";
+                        break;
+                }
             }
-            return String.Format("NGroupsFetchMessage({0})", output);
+            return String.Format("NGroupsFetchMessage(GroupIds={0}, Names={1})", ids, names);
         }
 
         public static NGroupsFetchMessage Default(params byte[][] ids)
@@ -113,45 +109,37 @@ namespace Nakama
 
             public Builder SetGroupIds(params byte[][] ids)
             {
-                message.payload.GroupsFetch.ClearSet();
-                message.payload.GroupsFetch.GroupIds = new TGroupsFetch.Types.GroupIds();
-                foreach (var id in ids)
-                {
-                    message.payload.GroupsFetch.GroupIds.GroupIds_.Add(ByteString.CopyFrom(id));
-                }
-                return this;
+                return SetGroupIds(new List<byte[]>(ids));
             }
 
             public Builder SetGroupIds(IEnumerable<byte[]> ids)
             {
-                message.payload.GroupsFetch.ClearSet();
-                message.payload.GroupsFetch.GroupIds = new TGroupsFetch.Types.GroupIds();
+                var groups = new List<TGroupsFetch.Types.GroupFetch>();
                 foreach (var id in ids)
                 {
-                    message.payload.GroupsFetch.GroupIds.GroupIds_.Add(ByteString.CopyFrom(id));
+                    var g = new TGroupsFetch.Types.GroupFetch();
+                    g.GroupId = ByteString.CopyFrom(id);
+                    groups.Add(g);
                 }
+                message.payload = new Envelope {GroupsFetch = new TGroupsFetch { Groups = {groups}}}; 
                 return this;
             }
 
             public Builder SetNames(params string[] names)
             {
-                message.payload.GroupsFetch.ClearSet();
-                message.payload.GroupsFetch.Names = new TGroupsFetch.Types.Names();
-                foreach (var name in names)
-                {
-                    message.payload.GroupsFetch.Names.Names_.Add(name);
-                }
-                return this;
+                return SetNames(new List<string>(names));
             }
 
             public Builder SetNames(IEnumerable<string> names)
             {
-                message.payload.GroupsFetch.ClearSet();
-                message.payload.GroupsFetch.Names = new TGroupsFetch.Types.Names();
+                var groups = new List<TGroupsFetch.Types.GroupFetch>();
                 foreach (var name in names)
                 {
-                    message.payload.GroupsFetch.Names.Names_.Add(name);
+                    var g = new TGroupsFetch.Types.GroupFetch();
+                    g.Name = name;
+                    groups.Add(g);
                 }
+                message.payload = new Envelope {GroupsFetch = new TGroupsFetch { Groups = {groups}}};
                 return this;
             }
 

--- a/Nakama/NLeaderboardRecordWriteMessage.cs
+++ b/Nakama/NLeaderboardRecordWriteMessage.cs
@@ -15,12 +15,13 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Google.Protobuf;
 
 namespace Nakama
 {
-    public class NLeaderboardRecordWriteMessage : INCollatedMessage<INLeaderboardRecord>
+    public class NLeaderboardRecordWriteMessage : INCollatedMessage<INResultSet<INLeaderboardRecord>>
     {
         private Envelope payload;
         public IMessage Payload {
@@ -31,14 +32,22 @@ namespace Nakama
 
         private NLeaderboardRecordWriteMessage()
         {
-            payload = new Envelope {LeaderboardRecordWrite = new TLeaderboardRecordWrite()};
+            payload = new Envelope {LeaderboardRecordsWrite = new TLeaderboardRecordsWrite()};
+            payload = new Envelope {LeaderboardRecordsWrite = new TLeaderboardRecordsWrite { Records =
+            {
+                new List<TLeaderboardRecordsWrite.Types.LeaderboardRecordWrite>()
+            }}};  
         }
 
         private NLeaderboardRecordWriteMessage(byte[] leaderboardId)
         {
-            var request = new TLeaderboardRecordWrite();
-            request.LeaderboardId = ByteString.CopyFrom(leaderboardId);
-            payload = new Envelope {LeaderboardRecordWrite = request};
+            payload = new Envelope {LeaderboardRecordsWrite = new TLeaderboardRecordsWrite { Records =
+            {
+                new List<TLeaderboardRecordsWrite.Types.LeaderboardRecordWrite>
+                {
+                    new TLeaderboardRecordsWrite.Types.LeaderboardRecordWrite {LeaderboardId = ByteString.CopyFrom(leaderboardId)}
+                }
+            }}};
         }
 
         public void SetCollationId(string id)
@@ -49,8 +58,12 @@ namespace Nakama
         public override string ToString()
         {
             var f = "NLeaderboardRecordWriteMessage(LeaderboardId={0},Location={1},Timezone={2},Metadata={3},Op={4},Incr={5},Decr={6},Set={7},Best={8})";
-            var p = payload.LeaderboardRecordWrite;
-            return String.Format(f, p.LeaderboardId, p.Location, p.Timezone, p.Metadata, p.OpCase, p.Incr, p.Decr, p.Set, p.Best);
+            var output = "";
+            foreach (var p in payload.LeaderboardRecordsWrite.Records)
+            {
+                output += String.Format(f, p.LeaderboardId, p.Location, p.Timezone, p.Metadata, p.OpCase, p.Incr, p.Decr, p.Set, p.Best); 
+            }
+            return output;   
         }
 
         public class Builder
@@ -64,47 +77,47 @@ namespace Nakama
 
             public Builder Location(string location)
             {
-                message.payload.LeaderboardRecordWrite.Location = location;
+                message.payload.LeaderboardRecordsWrite.Records[0].Location = location;
                 return this;
             }
 
             public Builder Timezone(string timezone)
             {
-                message.payload.LeaderboardRecordWrite.Timezone = timezone;
+                message.payload.LeaderboardRecordsWrite.Records[0].Timezone = timezone;
                 return this;
             }
 
             public Builder Metadata(byte[] metadata)
             {
-                message.payload.LeaderboardRecordWrite.Metadata = ByteString.CopyFrom(metadata);
+                message.payload.LeaderboardRecordsWrite.Records[0].Metadata = ByteString.CopyFrom(metadata);
                 return this;
             }
 
             public Builder Increment(long value)
             {
-                message.payload.LeaderboardRecordWrite.ClearOp();
-                message.payload.LeaderboardRecordWrite.Incr = value;
+                message.payload.LeaderboardRecordsWrite.Records[0].ClearOp();
+                message.payload.LeaderboardRecordsWrite.Records[0].Incr = value;
                 return this;
             }
 
             public Builder Decrement(long value)
             {
-                message.payload.LeaderboardRecordWrite.ClearOp();
-                message.payload.LeaderboardRecordWrite.Decr = value;
+                message.payload.LeaderboardRecordsWrite.Records[0].ClearOp();
+                message.payload.LeaderboardRecordsWrite.Records[0].Decr = value;
                 return this;
             }
 
             public Builder Set(long value)
             {
-                message.payload.LeaderboardRecordWrite.ClearOp();
-                message.payload.LeaderboardRecordWrite.Set = value;
+                message.payload.LeaderboardRecordsWrite.Records[0].ClearOp();
+                message.payload.LeaderboardRecordsWrite.Records[0].Set = value;
                 return this;
             }
 
             public Builder Best(long value)
             {
-                message.payload.LeaderboardRecordWrite.ClearOp();
-                message.payload.LeaderboardRecordWrite.Best = value;
+                message.payload.LeaderboardRecordsWrite.Records[0].ClearOp();
+                message.payload.LeaderboardRecordsWrite.Records[0].Best = value;
                 return this;
             }
 
@@ -113,7 +126,7 @@ namespace Nakama
                 // Clone object so builder now operates on new copy.
                 var original = message;
                 message = new NLeaderboardRecordWriteMessage();
-                message.payload.LeaderboardRecordWrite = new TLeaderboardRecordWrite(original.payload.LeaderboardRecordWrite);
+                message.payload.LeaderboardRecordsWrite = new TLeaderboardRecordsWrite(original.payload.LeaderboardRecordsWrite);
                 return original;
             }
         }

--- a/Nakama/NMatch.cs
+++ b/Nakama/NMatch.cs
@@ -26,7 +26,9 @@ namespace Nakama
         public IList<INUserPresence> Presence { get; private set; }
         public INUserPresence Self { get; private set; }
 
-        internal NMatch(TMatch message)
+        internal NMatch(TMatch message): this(message.Match) {}
+        
+        internal NMatch(Match message)
         {
             Id = message.MatchId.ToByteArray();
             Presence = new List<INUserPresence>();

--- a/Nakama/NMatchJoinMessage.cs
+++ b/Nakama/NMatchJoinMessage.cs
@@ -15,11 +15,12 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
 {
-    public class NMatchJoinMessage : INCollatedMessage<INMatch>
+    public class NMatchJoinMessage : INCollatedMessage<INResultSet<INMatch>>
     {
         private Envelope payload;
         public IMessage Payload {
@@ -30,14 +31,24 @@ namespace Nakama
 
         private NMatchJoinMessage(byte[] matchId)
         {
-            payload = new Envelope {MatchJoin = new TMatchJoin()};
-            payload.MatchJoin.MatchId = ByteString.CopyFrom(matchId);
+            payload = new Envelope {MatchesJoin = new TMatchesJoin { Matches =
+            {
+                new List<TMatchesJoin.Types.MatchJoin>
+                {
+                    new TMatchesJoin.Types.MatchJoin{ MatchId = ByteString.CopyFrom(matchId) }
+                }
+            }}};   
         }
 
         private NMatchJoinMessage(INMatchToken token)
         {
-            payload = new Envelope {MatchJoin = new TMatchJoin()};
-            payload.MatchJoin.Token = ByteString.CopyFrom(token.Token);
+            payload = new Envelope {MatchesJoin = new TMatchesJoin { Matches =
+            {
+                new List<TMatchesJoin.Types.MatchJoin>
+                {
+                    new TMatchesJoin.Types.MatchJoin{ Token = ByteString.CopyFrom(token.Token) }
+                }
+            }}};   
         }
 
         public void SetCollationId(string id)
@@ -48,7 +59,7 @@ namespace Nakama
         public override string ToString()
         {
             var f = "NMatchJoinMessage(MatchId={0},Token={1})";
-            return String.Format(f, payload.MatchJoin.MatchId, payload.MatchJoin.Token);
+            return String.Format(f, payload.MatchesJoin.Matches[0].MatchId, payload.MatchesJoin.Matches[0].Token);
         }
 
         public static NMatchJoinMessage Default(byte[] matchId)

--- a/Nakama/NMatchLeaveMessage.cs
+++ b/Nakama/NMatchLeaveMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,8 +31,10 @@ namespace Nakama
 
         private NMatchLeaveMessage(byte[] matchId)
         {
-            payload = new Envelope {MatchLeave = new TMatchLeave()};
-            payload.MatchLeave.MatchId = ByteString.CopyFrom(matchId);
+            payload = new Envelope {MatchesLeave = new TMatchesLeave { MatchIds =
+            {
+                new List<ByteString>{ ByteString.CopyFrom(matchId) }
+            }}};   
         }
 
         public void SetCollationId(string id)
@@ -41,8 +44,12 @@ namespace Nakama
 
         public override string ToString()
         {
-            var f = "NMatchLeaveMessage(MatchId={0})";
-            return String.Format(f, payload.MatchLeave.MatchId);
+            var output = "";
+            foreach (var id in payload.MatchesLeave.MatchIds)
+            {
+                output += id + ", ";
+            }
+            return String.Format("NMatchLeaveMessage(GroupIds={0})", output);   
         }
 
         public static NMatchLeaveMessage Default(byte[] matchId)

--- a/Nakama/NSelf.cs
+++ b/Nakama/NSelf.cs
@@ -64,7 +64,7 @@ namespace Nakama
             AvatarUrl = message.User.AvatarUrl;
             CreatedAt = message.User.CreatedAt;
             CustomId = message.CustomId;
-            DeviceIds = message.DeviceId;
+            DeviceIds = message.DeviceIds;
             Email = message.Email;
             FacebookId = message.FacebookId;
             Fullname = message.User.Fullname;

--- a/Nakama/NStorageKey.cs
+++ b/Nakama/NStorageKey.cs
@@ -28,7 +28,7 @@ namespace Nakama
 
         public byte[] Version { get; private set; }
 
-        internal NStorageKey(TStorageKey.Types.StorageKey message)
+        internal NStorageKey(TStorageKeys.Types.StorageKey message)
         {
             Bucket = message.Bucket;
             Collection = message.Collection;

--- a/Nakama/NTopic.cs
+++ b/Nakama/NTopic.cs
@@ -25,9 +25,9 @@ namespace Nakama
         public IList<INUserPresence> Presences { get; private set; }
         public INUserPresence Self { get; private set; }
 
-        internal NTopic(TTopic message)
+        internal NTopic(TTopics.Types.Topic message)
         {
-            Topic = new NTopicId(message.Topic);
+            Topic = new NTopicId(message.Topic_);
             Presences = new List<INUserPresence>();
             foreach (var presence in message.Presences)
             {

--- a/Nakama/NTopicJoinMessage.cs
+++ b/Nakama/NTopicJoinMessage.cs
@@ -15,11 +15,12 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
 {
-    public class NTopicJoinMessage : INCollatedMessage<INTopic>
+    public class NTopicJoinMessage : INCollatedMessage<INResultSet<INTopic>>
     {
         private Envelope payload;
         public IMessage Payload {
@@ -30,7 +31,10 @@ namespace Nakama
 
         private NTopicJoinMessage()
         {
-            payload = new Envelope {TopicJoin = new TTopicJoin()};
+            payload = new Envelope {TopicsJoin = new TTopicsJoin {Joins =
+            {
+                new List<TTopicsJoin.Types.TopicJoin>()
+            }}};   
         }
 
         public void SetCollationId(string id)
@@ -40,22 +44,24 @@ namespace Nakama
 
         public override string ToString()
         {
-            var f = "NTopicJoinMessage(Id={0},IdCase={1})";
-            var p = payload.TopicJoin;
-            byte[] id = null;
-            switch (p.IdCase)
+            var p = payload.TopicsJoin;
+            string output = "";
+            foreach (var j in p.Joins)
             {
-                case TTopicJoin.IdOneofCase.UserId:
-                    id = p.UserId.ToByteArray();
-                    break;
-                case TTopicJoin.IdOneofCase.Room:
-                    id = p.Room.ToByteArray();
-                    break;
-                case TTopicJoin.IdOneofCase.GroupId:
-                    id = p.GroupId.ToByteArray();
-                    break;
+                switch (j.IdCase)
+                {
+                    case TTopicsJoin.Types.TopicJoin.IdOneofCase.UserId:
+                        output += String.Format("(Id={0},IdCase={1}),", j.UserId.ToByteArray(), j.IdCase);
+                        break;
+                    case TTopicsJoin.Types.TopicJoin.IdOneofCase.Room:
+                        output += String.Format("(Id={0},IdCase={1}),", j.Room.ToByteArray(), j.IdCase);
+                        break;
+                    case TTopicsJoin.Types.TopicJoin.IdOneofCase.GroupId:
+                        output += String.Format("(Id={0},IdCase={1}),", j.GroupId.ToByteArray(), j.IdCase);
+                        break;
+                }
             }
-            return String.Format(f, id, p.IdCase);
+            return String.Format("NTopicJoinMessage({0})", output);
         }
 
         public class Builder
@@ -69,22 +75,28 @@ namespace Nakama
 
             public Builder TopicDirectMessage(byte[] userId)
             {
-                message.payload.TopicJoin.ClearId();
-                message.payload.TopicJoin.UserId = ByteString.CopyFrom(userId);
+                message.payload.TopicsJoin.Joins.Add(new TTopicsJoin.Types.TopicJoin
+                {
+                    UserId = ByteString.CopyFrom(userId)
+                });
                 return this;
             }
 
             public Builder TopicRoom(byte[] room)
             {
-                message.payload.TopicJoin.ClearId();
-                message.payload.TopicJoin.Room = ByteString.CopyFrom(room);
+                message.payload.TopicsJoin.Joins.Add(new TTopicsJoin.Types.TopicJoin
+                {
+                    Room = ByteString.CopyFrom(room)
+                });
                 return this;
             }
 
             public Builder TopicGroup(byte[] groupId)
             {
-                message.payload.TopicJoin.ClearId();
-                message.payload.TopicJoin.GroupId = ByteString.CopyFrom(groupId);
+                message.payload.TopicsJoin.Joins.Add(new TTopicsJoin.Types.TopicJoin
+                {
+                    GroupId= ByteString.CopyFrom(groupId)
+                });
                 return this;
             }
 
@@ -93,7 +105,7 @@ namespace Nakama
                 // Clone object so builder now operates on new copy.
                 var original = message;
                 message = new NTopicJoinMessage();
-                message.payload.TopicJoin = new TTopicJoin(original.payload.TopicJoin);
+                message.payload.TopicsJoin = new TTopicsJoin(original.payload.TopicsJoin);
                 return original;
             }
         }

--- a/Nakama/NTopicLeaveMessage.cs
+++ b/Nakama/NTopicLeaveMessage.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Google.Protobuf;
 
 namespace Nakama
@@ -30,20 +31,23 @@ namespace Nakama
 
         private NTopicLeaveMessage(INTopicId topic)
         {
-            payload = new Envelope {TopicLeave = new TTopicLeave()};
-            payload.TopicLeave.Topic = new TopicId();
+            var topicId = new TopicId();
             switch (topic.Type)
             {
                 case TopicType.DirectMessage:
-                    payload.TopicLeave.Topic.Dm = ByteString.CopyFrom(topic.Id);
+                    topicId.Dm = ByteString.CopyFrom(topic.Id);
                     break;
                 case TopicType.Room:
-                    payload.TopicLeave.Topic.Room = ByteString.CopyFrom(topic.Id);
+                    topicId.Room = ByteString.CopyFrom(topic.Id);
                     break;
                 case TopicType.Group:
-                    payload.TopicLeave.Topic.GroupId = ByteString.CopyFrom(topic.Id);
+                    topicId.GroupId = ByteString.CopyFrom(topic.Id);
                     break;
             }
+            payload = new Envelope {TopicsLeave = new TTopicsLeave { Topics =
+            {
+                new List<TopicId> { topicId }
+            }}};      
         }
 
         public void SetCollationId(string id)
@@ -52,8 +56,8 @@ namespace Nakama
         }
 
         public override string ToString()
-        {
-            return String.Format("NTopicLeaveMessage(Topic={0})", payload.TopicLeave.Topic);
+        {   
+            return String.Format("NTopicLeaveMessage(Topic={0})", payload.TopicsLeave.Topics);
         }
 
         public static NTopicLeaveMessage Default(INTopicId topic)


### PR DESCRIPTION
Couple of API changes:
- `NTopicJoinMessage` requires a `INResultSet<INTopic>` (as opposed to just `INTopic`)
- `NLeaderboardRecordWriteMessage` requires a `INResultSet<INLeaderboardRecord>`

#### Internal behaviour changes:
Applies to:
- NGroupsFetchMessage
- NUsersFetchMessage

The builder methods no longer replace the entire list of items. Instead they append to it. This is because we no longer have the OneOf separation on the list level, but rather inside each item of the list. 

#### Batching Todo:
All other classes only process the first item of the list, and write to the first item of the list. I've tried to keep as much of the API the same.

#### Fixes:
- In `NUsersFetchMessage`, the `Add` method on the builder is now fixed so it can take an array of ByteArrays. 