### PR TITLE
added network disconnect error event handler

### DIFF
--- a/Nakama/INClient.cs
+++ b/Nakama/INClient.cs
@@ -28,7 +28,7 @@ namespace Nakama
 
         INLogger Logger { get; }
 
-        event EventHandler OnDisconnect;
+        event EventHandler<NDisconnectErrorEventArgs> OnDisconnect;
 
         event EventHandler<NErrorEventArgs> OnError;
 
@@ -41,8 +41,6 @@ namespace Nakama
         event EventHandler<NTopicMessageEventArgs> OnTopicMessage;
 
         event EventHandler<NTopicPresenceEventArgs> OnTopicPresence;
-        
-        event EventHandler<NNotificationEventArgs> OnNotification;
 
         uint Port { get; }
 

--- a/Nakama/INError.cs
+++ b/Nakama/INError.cs
@@ -23,22 +23,19 @@ namespace Nakama
         MissingPayload,
         BadInput,
         AuthError,
-        UserNotFound,
-        UserRegisterInuse,
         UserLinkInuse,
         UserLinkProviderUnavailable,
-        UserUnlinkDisallowed,
+        UserLinkDisallowed,
         UserHandleInuse,
         GroupNameInuse,
         StorageRejected,
-        MatchNotFound,
-        RuntimeFunctionNotFound,
-        RuntimeFunctionException
+        MatchNotFound
     }
 
     public interface INError
     {
         ErrorCode Code { get; }
+        int eCode { get; }
         string Message { get; }
     }
 }

--- a/Nakama/NDisconnectErrorEventArgs.cs
+++ b/Nakama/NDisconnectErrorEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using Nakama;
+using System;
+
+public class NDisconnectErrorEventArgs : EventArgs
+{
+    public INError Error { get; private set; }
+
+    internal NDisconnectErrorEventArgs(NError error)
+    {
+        Error = error;
+    }
+}

--- a/Nakama/NError.cs
+++ b/Nakama/NError.cs
@@ -22,6 +22,7 @@ namespace Nakama
     internal class NError : INError
     {
         public ErrorCode Code { get; private set; }
+        public int eCode { get; private set; }
         public string Message { get; private set; }
 
         internal NError(AuthenticateResponse.Types.Error error)
@@ -53,6 +54,12 @@ namespace Nakama
         internal NError(string message)
         {
             Code = ErrorCode.Unknown;
+            Message = message;
+        }
+
+        internal NError(int code, string message)
+        {
+            eCode = code;
             Message = message;
         }
 

--- a/example/Matchmake.cs
+++ b/example/Matchmake.cs
@@ -102,7 +102,8 @@ public class Matchmake : MonoBehaviour {
 
     private void RegisterAndConnect() {
         // Lets log a message whenever we're disconnected from the server.
-        _client.OnDisconnect += (object sender, EventArgs args) => {
+        _client.OnDisconnect += (object sender, NDisconnectErrorEventArgs args) =>
+        {
             Debug.Log("Disconnected from the server.");
         };
 


### PR DESCRIPTION
in order to get server side error codes
We wanted to check if the previous session of the client was expired or not, that’s why we added an handler to get the server side error codes. If the session is already expired, we’re creating a new session.
This is especially useful for cases like unstable client network connections.