### PR TITLE
Fix detection of non-200 HTTP error codes in websocket auth

### DIFF
--- a/Nakama/NTransportWebSocket.cs
+++ b/Nakama/NTransportWebSocket.cs
@@ -112,11 +112,6 @@ namespace Nakama
                     }
                     catch (WebException e)
                     {
-                        if (e.Response is HttpWebResponse)
-                        {
-                            successAction(e.Response as HttpWebResponse);
-                            return;
-                        }
                         errorAction(e);
                     }
                 }, request);


### PR DESCRIPTION
Previously a HTTP error like 502 would not be caught and the protobuf decode would fail instead, throwing an exception which would be undetectable to the app. This is easy to reproduce with a load balancer setup, just stop the Nakama service and you will get a 502: Bad Gateway. The original code would never call back either the success or error callbacks from `client.Login`.

I also changed all other loggin-only error cases into error callbacks so that callers can rely on some response in all cases.