### PR TITLE
downloadHandler is null on DELETE methods.

### DIFF
--- a/Assets/Nakama/UnityWebRequestAdapter.cs
+++ b/Assets/Nakama/UnityWebRequestAdapter.cs
@@ -127,7 +127,7 @@ namespace Nakama
             }
             else
             {
-                callback?.Invoke(www.downloadHandler.text);
+                callback?.Invoke(www.downloadHandler?.text);
             }
         }
     }


### PR DESCRIPTION
Found this bug when I was trying to delete a friend.  It deleted just fine but then threw a null exception and stopped all execution.

Turns out www.downloadHandler wasn't available when the method is DELETE .  I'm not sure if this is intentional, but this should fix it.