### PR TITLE
only call dispose after www is guaranteed to be done getting used

### DIFF
--- a/Packages/Nakama/CHANGELOG.md
+++ b/Packages/Nakama/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fixed a race condition that could occur when Unity web requests were cancelled.
+
 ## [3.5.0] - 2022-09-18
 ### Changed
 - Update to use Nakama .NET 3.5.0 release.

--- a/Packages/Nakama/Runtime/UnityWebRequestAdapter.cs
+++ b/Packages/Nakama/Runtime/UnityWebRequestAdapter.cs
@@ -77,7 +77,6 @@ namespace Nakama
             var tcs = new TaskCompletionSource<string>();
             cancellationToken?.Register(() => tcs.SetCanceled());
             StartCoroutine(SendRequest(www, resp => tcs.SetResult(resp), err => tcs.SetException(err)));
-            tcs.Task.ContinueWith(res => www.Dispose());
             return tcs.Task;
         }
 
@@ -128,6 +127,7 @@ namespace Nakama
                     // TODO think of best way to map HTTP code to GRPC code since we can't rely
                     // on server to process it. Manually adding the mapping to SDK seems brittle.
                     errback(new ApiResponseException((int) www.responseCode, www.downloadHandler.text, -1));
+                    www.Dispose();
                     yield break;
                 }
 
@@ -154,6 +154,8 @@ namespace Nakama
             {
                 callback?.Invoke(www.downloadHandler?.text);
             }
+
+            www.Dispose();
         }
 
         private static bool IsHttpError(UnityWebRequest www)


### PR DESCRIPTION
If a user cancelled a Unity web request with a cancellation token, there was a chance that the web request would have `Dispose()` called on it while it was still being used in the request coroutine. This leads to runtime exceptions. 

This should resolve the issue by only disposing `www` in the coroutine instead of the task continuation.