### PR TITLE
only update coroutine task if it has not been transitioned already

### DIFF
--- a/Packages/Nakama/CHANGELOG.md
+++ b/Packages/Nakama/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
-- Fixed a race condition that could occur when Unity web requests were cancelled.
+- Fixed multiple race conditions that could occur when Unity web requests were cancelled.
 
 ## [3.5.0] - 2022-09-18
 ### Changed

--- a/Packages/Nakama/Runtime/UnityWebRequestAdapter.cs
+++ b/Packages/Nakama/Runtime/UnityWebRequestAdapter.cs
@@ -75,28 +75,8 @@ namespace Nakama
         {
             var www = BuildRequest(method, uri, headers, body, timeout);
             var tcs = new TaskCompletionSource<string>();
-            cancellationToken?.Register(() =>
-            {
-                if (!tcs.Task.IsCompleted)
-                {
-                    tcs.SetCanceled();
-                }
-            });
-            StartCoroutine(SendRequest(www, resp =>
-            {
-                if (!tcs.Task.IsCompleted)
-                {
-                    tcs.SetResult(resp);
-                }
-            },
-            err =>
-            {
-                if (!tcs.Task.IsCompleted)
-                {
-                    tcs.SetException(err);
-                }
-            }));
-
+            cancellationToken?.Register(() => tcs.TrySetCanceled());
+            StartCoroutine(SendRequest(www, resp => tcs.TrySetResult(resp), err => tcs.TrySetException(err)));
             return tcs.Task;
         }
 

--- a/Packages/Nakama/Runtime/UnityWebRequestAdapter.cs
+++ b/Packages/Nakama/Runtime/UnityWebRequestAdapter.cs
@@ -75,8 +75,28 @@ namespace Nakama
         {
             var www = BuildRequest(method, uri, headers, body, timeout);
             var tcs = new TaskCompletionSource<string>();
-            cancellationToken?.Register(() => tcs.SetCanceled());
-            StartCoroutine(SendRequest(www, resp => tcs.SetResult(resp), err => tcs.SetException(err)));
+            cancellationToken?.Register(() =>
+            {
+                if (!tcs.Task.IsCompleted)
+                {
+                    tcs.SetCanceled();
+                }
+            });
+            StartCoroutine(SendRequest(www, resp =>
+            {
+                if (!tcs.Task.IsCompleted)
+                {
+                    tcs.SetResult(resp);
+                }
+            },
+            err =>
+            {
+                if (!tcs.Task.IsCompleted)
+                {
+                    tcs.SetException(err);
+                }
+            }));
+
             return tcs.Task;
         }
 


### PR DESCRIPTION
We use a `tcs` to handle the translation of a Unity Coroutine to a `Task`.

We shouldn't cancel, complete or set an exception on the `tcs` if it has already been transitioned. This can happen, pretty easily actually if an exception occurs from the network and then the user tries to cancel it the request, or vice versa.