### PR TITLE
webgl socket - don't remove js socket from handlers immediately after close

### DIFF
--- a/Packages/Nakama/Runtime/JsWebSocketAdapter.cs
+++ b/Packages/Nakama/Runtime/JsWebSocketAdapter.cs
@@ -213,7 +213,6 @@ namespace Nakama
         public void Close(int socketRef)
         {
             NKCloseSocket(socketRef);
-            _handlers.Remove(socketRef);
         }
 
         public void Send(int socketRef, string payload)


### PR DESCRIPTION
the handler was being removed immediately which caused `OnClose` not to fire. 

since the handler will be removed later when receiving the close event or an error from the dom object, we can confidently remove the removal here.