### PR TITLE
Removed unnecessary reference to old Nakama Unity version in Demo scene.

### DIFF
--- a/Packages/Nakama/CHANGELOG.md
+++ b/Packages/Nakama/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ### [Unreleased]
 
+### Fixed
+- Removed unnecessary reference to old Nakama Unity version in Demo scene.
+
 ## [3.11.0] - 2024-03-08
 
 ### Changed

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.heroiclabs.nakama-unity": "https://github.com/heroiclabs/nakama-unity.git?path=/Packages/Nakama#v3.0.0",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.modules.jsonserialize": "1.0.0",
     "com.unity.modules.ui": "1.0.0",


### PR DESCRIPTION
- No need to reference it in manifest since the package already lives in the Packages/ folder.