### PR TITLE
Replace obsolete function 'Pointer_stringify' with 'UTF8ToString'.

### DIFF
--- a/Packages/Nakama/Runtime/Plugins/UnityWebGLSocketBridge.jslib
+++ b/Packages/Nakama/Runtime/Plugins/UnityWebGLSocketBridge.jslib
@@ -41,7 +41,7 @@ var UnityWebGLSocketBridge = {
             return;
         }
 
-        var address = Pointer_stringify(addressPtr);
+        var address = UTF8ToString(addressPtr);
         var ws = new WebSocket(address);
         ws.onmessage = function(e) {
             if (typeof e.data == 'string') {
@@ -97,7 +97,7 @@ var UnityWebGLSocketBridge = {
         if(!SOCKET_REF_MAP.has(socketRef)) {
             SendMessage(BRIDGE_NAME, ERROR_METHOD_NAME, socketRef + "_" + "Did not find websocket with given reference.");
         } else {
-            var data = Pointer_stringify(msg);
+            var data = UTF8ToString(msg);
             SOCKET_REF_MAP.get(socketRef).send(data);
         }
     },


### PR DESCRIPTION
`Pointer_stringify` is obsolete since Unity 2021.2: https://forum.unity.com/threads/pointer_stringify-is-not-defined-pass-string-to-js.701501/

Each Unity version has a different version of Emscripten internally. For Unity < 2021.2 it uses Emscripten 1.38.11. `UTF8ToString` was added in even older versions of Emscripten, so it's safe to just replace the function to `UTF8ToString`.
